### PR TITLE
fix: devDependency cleanup

### DIFF
--- a/.changeset/many-hands-love.md
+++ b/.changeset/many-hands-love.md
@@ -1,0 +1,7 @@
+---
+'@journeyapps-labs/micro-streaming': patch
+'@journeyapps-labs/micro-codecs': patch
+'@journeyapps-labs/micro-schema': patch
+---
+
+Moved development dependencies to devDependencies.

--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -20,11 +20,11 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@types/node": "^24.7.0",
     "bson": "^6.10.4",
     "ts-codec": "^1.3.0"
   },
   "devDependencies": {
-    "@types/node": "^24.7.0",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -20,9 +20,11 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@types/node": "^24.7.0",
     "bson": "^6.10.4",
-    "ts-codec": "^1.3.0",
+    "ts-codec": "^1.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.0",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -26,7 +26,9 @@
     "ajv": "^8.17.1",
     "better-ajv-errors": "^2.0.2",
     "ts-codec": "^1.3.0",
-    "vitest": "^3.2.4",
     "zod": "^4.1.12"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/streaming/package.json
+++ b/packages/streaming/package.json
@@ -27,10 +27,10 @@
   "dependencies": {
     "@journeyapps-labs/micro-errors": "workspace:^",
     "@journeyapps-labs/micro-schema": "workspace:^",
-    "@types/express": "^5.0.3",
     "bson": "^6.10.4"
   },
   "devDependencies": {
+    "@types/express": "^5.0.3",
     "@types/lodash": "^4.17.20",
     "lodash": "^4.17.21",
     "vitest": "^3.2.4"

--- a/packages/streaming/package.json
+++ b/packages/streaming/package.json
@@ -27,10 +27,10 @@
   "dependencies": {
     "@journeyapps-labs/micro-errors": "workspace:^",
     "@journeyapps-labs/micro-schema": "workspace:^",
+    "@types/express": "^5.0.3",
     "bson": "^6.10.4"
   },
   "devDependencies": {
-    "@types/express": "^5.0.3",
     "@types/lodash": "^4.17.20",
     "lodash": "^4.17.21",
     "vitest": "^3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,13 +82,13 @@ importers:
       '@journeyapps-labs/micro-schema':
         specifier: workspace:^
         version: link:../schema
+      '@types/express':
+        specifier: ^5.0.3
+        version: 5.0.3
       bson:
         specifier: ^6.10.4
         version: 6.10.4
     devDependencies:
-      '@types/express':
-        specifier: ^5.0.3
-        version: 5.0.3
       '@types/lodash':
         specifier: ^4.17.20
         version: 4.17.20

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   packages/codecs:
     dependencies:
+      '@types/node':
+        specifier: ^24.7.0
+        version: 24.7.0
       bson:
         specifier: ^6.10.4
         version: 6.10.4
@@ -30,9 +33,6 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
     devDependencies:
-      '@types/node':
-        specifier: ^24.7.0
-        version: 24.7.0
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.7.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,15 +23,16 @@ importers:
 
   packages/codecs:
     dependencies:
-      '@types/node':
-        specifier: ^24.7.0
-        version: 24.7.0
       bson:
         specifier: ^6.10.4
         version: 6.10.4
       ts-codec:
         specifier: ^1.3.0
         version: 1.3.0
+    devDependencies:
+      '@types/node':
+        specifier: ^24.7.0
+        version: 24.7.0
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.7.0)
@@ -65,12 +66,13 @@ importers:
       ts-codec:
         specifier: ^1.3.0
         version: 1.3.0
-      vitest:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.7.0)
       zod:
         specifier: ^4.1.12
         version: 4.1.12
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.7.0)
 
   packages/streaming:
     dependencies:
@@ -80,13 +82,13 @@ importers:
       '@journeyapps-labs/micro-schema':
         specifier: workspace:^
         version: link:../schema
-      '@types/express':
-        specifier: ^5.0.3
-        version: 5.0.3
       bson:
         specifier: ^6.10.4
         version: 6.10.4
     devDependencies:
+      '@types/express':
+        specifier: ^5.0.3
+        version: 5.0.3
       '@types/lodash':
         specifier: ^4.17.20
         version: 4.17.20


### PR DESCRIPTION
## Overview

PowerSync now uses `@journeyapps-labs/common-sdk` for interfacing with some of our micro-services. While working with this, we noticed that a few packages in `micro` had `vitest` listed under `dependencies` instead of `devDependencies`. Because of this, downstream consumers were unnecessarily pulling in those transitive packages, which added bloat to their `node_modules`.

This PR moves `vitest` to `devDependencies`. No runtime code has changed.

Affected packages: `@journeyapps-labs/micro-codecs` and `@journeyapps-labs/micro-schema`.

## Changes

### `vitest` → moved to `devDependencies`
Only used during testing — no published type definitions reference it, so there's no reason for consumers to install it.

### `@types/node` → **kept in `dependencies`** in `micro-codecs`
The published `.d.ts` files for `micro-codecs` expose `Buffer` in their public API (e.g. `Codec<Buffer<ArrayBufferLike>, ...>`). `Buffer` is a Node.js global typed by `@types/node`, so consumers need it available to compile against these types.

### `@types/express` → **kept in `dependencies`** in `micro-streaming`
The published `.d.ts` files for `micro-streaming` explicitly import express types (e.g. `express.Request`, `express.Response`). Moving it to `devDependencies` would cause TypeScript errors for consumers who don't have `@types/express` installed themselves.

## Additional Context

`@journeyapps-labs/common-sdk` depends on some of these `micro` packages, which is how we spotted the issue:

```
├─┬ @powersync/cli-core link:packages/cli-core
│ ├─┬ @journeyapps-labs/common-sdk 1.0.2
│ │ └─┬ @journeyapps-labs/micro-streaming 1.0.1
│ │   └── @journeyapps-labs/micro-schema 1.0.1
```
