### PR TITLE
Add validation to ResourceId and ObjectId

### DIFF
--- a/.changeset/loose-dryers-lead.md
+++ b/.changeset/loose-dryers-lead.md
@@ -1,6 +1,6 @@
 ---
-'@journeyapps-labs/micro-codecs': minor
-'@journeyapps-labs/micro-schema': minor
+'@journeyapps-labs/micro-codecs': patch
+'@journeyapps-labs/micro-schema': patch
 ---
 
 Validate ObjectId and ResourceId.id match bson ObjectId format.

--- a/.changeset/loose-dryers-lead.md
+++ b/.changeset/loose-dryers-lead.md
@@ -1,0 +1,6 @@
+---
+'@journeyapps-labs/micro-codecs': minor
+'@journeyapps-labs/micro-schema': minor
+---
+
+Validate ObjectId and ResourceId.id match bson ObjectId format.

--- a/packages/codecs/src/parsers.ts
+++ b/packages/codecs/src/parsers.ts
@@ -4,7 +4,7 @@ import * as t from 'ts-codec';
 export const ObjectIdParser = t.createParser<typeof codecs.ObjectId>(codecs.ObjectId._tag, (_, { target }) => {
   switch (target) {
     case t.TransformTarget.Encoded: {
-      return { type: 'string' };
+      return { type: 'string', bsonObjectId: true };
     }
     case t.TransformTarget.Decoded: {
       return { bsonType: 'ObjectId' };
@@ -18,7 +18,7 @@ export const ResourceIdParser = t.createParser<typeof codecs.ResourceId>(codecs.
       return {
         type: 'object',
         properties: {
-          id: { type: 'string' }
+          id: { type: 'string', bsonObjectId: true }
         },
         required: ['id']
       };

--- a/packages/codecs/tests/__snapshots__/parsers.test.ts.snap
+++ b/packages/codecs/tests/__snapshots__/parsers.test.ts.snap
@@ -128,6 +128,7 @@ exports[`parsers > should correctly generate ObjectId schemas 1`] = `
     "definitions": {},
   },
   "encoded": {
+    "bsonObjectId": true,
     "definitions": {},
     "type": "string",
   },
@@ -152,6 +153,7 @@ exports[`parsers > should correctly generate ResourceId schemas 1`] = `
     "definitions": {},
     "properties": {
       "id": {
+        "bsonObjectId": true,
         "type": "string",
       },
     },

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -25,6 +25,7 @@
     "@journeyapps-labs/micro-errors": "workspace:^",
     "ajv": "^8.17.1",
     "better-ajv-errors": "^2.0.2",
+    "bson": "^6.10.4",
     "ts-codec": "^1.3.0",
     "zod": "^4.1.12"
   },

--- a/packages/schema/src/json-schema/keywords.ts
+++ b/packages/schema/src/json-schema/keywords.ts
@@ -1,4 +1,20 @@
 import * as ajv from 'ajv';
+import { ObjectId } from 'bson';
+
+export const ObjectIdKeyword: ajv.KeywordDefinition = {
+  keyword: 'bsonObjectId',
+  metaSchema: { type: 'boolean' },
+  error: {
+    message: 'should be a valid ObjectId string'
+  },
+  code(context) {
+    const fn = context.gen.scopeValue('func', {
+      ref: ObjectId.isValid,
+      code: ajv._`require('bson').ObjectId.isValid`
+    });
+    context.fail(ajv._`!${fn}(${context.data})`);
+  }
+};
 
 export const BufferNodeType: ajv.KeywordDefinition = {
   keyword: 'nodeType',

--- a/packages/schema/src/validators/schema-validator.ts
+++ b/packages/schema/src/validators/schema-validator.ts
@@ -38,7 +38,7 @@ export const createSchemaValidator = <T = any>(
   try {
     const ajv = new AJV({
       allErrors: !(params.fail_fast ?? false),
-      keywords: [keywords.BufferNodeType],
+      keywords: [keywords.BufferNodeType, keywords.ObjectIdKeyword],
       ...(params.ajv || {})
     });
 

--- a/packages/schema/tests/schema-validation.test.ts
+++ b/packages/schema/tests/schema-validation.test.ts
@@ -2,6 +2,7 @@ import { describe, test, it, expect } from 'vitest';
 
 import base_schema from './fixtures/schema';
 import * as micro_schema from '../src';
+import * as codecs from '@journeyapps-labs/micro-codecs';
 
 const base_validator = micro_schema.createSchemaValidator(base_schema);
 
@@ -154,14 +155,16 @@ describe('json-schema-validation', () => {
     expect(res2).toMatchSnapshot();
   });
 
-  it('should validate bsonObjectId fields', () => {
-    const validator = micro_schema.createSchemaValidator({
-      type: 'object',
-      properties: {
-        id: { type: 'string', bsonObjectId: true }
-      },
-      required: ['id']
-    });
+  it('should validate bsonObjectId fields for ObjectId', () => {
+    const validator = micro_schema.createTsCodecValidator(codecs.ObjectId);
+
+    expect(validator.validate('507f1f77bcf86cd799439011').valid).toBe(true);
+    expect(validator.validate('not-an-objectid').valid).toBe(false);
+    expect(validator.validate('507f1f77bcf86cd79943901').valid).toBe(false);
+  });
+
+  it('should validate bsonObjectId fields for ResourceId', () => {
+    const validator = micro_schema.createTsCodecValidator(codecs.ResourceId);
 
     expect(validator.validate({ id: '507f1f77bcf86cd799439011' }).valid).toBe(true);
     expect(validator.validate({ id: 'not-an-objectid' }).valid).toBe(false);

--- a/packages/schema/tests/schema-validation.test.ts
+++ b/packages/schema/tests/schema-validation.test.ts
@@ -154,6 +154,20 @@ describe('json-schema-validation', () => {
     expect(res2).toMatchSnapshot();
   });
 
+  it('should validate bsonObjectId fields', () => {
+    const validator = micro_schema.createSchemaValidator({
+      type: 'object',
+      properties: {
+        id: { type: 'string', bsonObjectId: true }
+      },
+      required: ['id']
+    });
+
+    expect(validator.validate({ id: '507f1f77bcf86cd799439011' }).valid).toBe(true);
+    expect(validator.validate({ id: 'not-an-objectid' }).valid).toBe(false);
+    expect(validator.validate({ id: '507f1f77bcf86cd79943901' }).valid).toBe(false);
+  });
+
   it('should fail to compile invalid node types', () => {
     try {
       micro_schema.createSchemaValidator({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       better-ajv-errors:
         specifier: ^2.0.2
         version: 2.0.2(ajv@8.17.1)
+      bson:
+        specifier: ^6.10.4
+        version: 6.10.4
       ts-codec:
         specifier: ^1.3.0
         version: 1.3.0


### PR DESCRIPTION
Adds `bsonObjectId` keyword which validates that the ObjectId codec and the ResourceId.id field are valid BSON ObjectIds.

Note that this is possible with less code via `pattern: '^[0-9a-fA-F]{24}$'` in the ObjectId codec; however this approach benefits from being able to call `ObjectId.isValid` directly.